### PR TITLE
Refactor: 로그인 로직 수정 및 dto 변경

### DIFF
--- a/src/main/java/com/nhnacademy/front/adaptor/UserAdaptor.java
+++ b/src/main/java/com/nhnacademy/front/adaptor/UserAdaptor.java
@@ -1,16 +1,17 @@
 package com.nhnacademy.front.adaptor;
 
-import com.nhnacademy.front.dto.AccessTokenResponse;
 import com.nhnacademy.front.dto.LoginRequest;
 import com.nhnacademy.front.dto.UserRegisterRequest;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import java.util.Map;
+
 
 @FeignClient(value = "user-management", url = "${gateway.url}")
 public interface UserAdaptor {
     @PostMapping("/api/auth/login")
-    AccessTokenResponse doLogin(LoginRequest loginRequest);
+    Map<String, Object> doLogin(LoginRequest loginRequest);
     @PostMapping("/api/user/register")
     void createUser(UserRegisterRequest userRegisterRequest);
 }

--- a/src/main/java/com/nhnacademy/front/controller/LoginController.java
+++ b/src/main/java/com/nhnacademy/front/controller/LoginController.java
@@ -34,6 +34,9 @@ public class LoginController {
         Cookie accessCookie = new Cookie("accessToken", accessTokenResponse.getAccessToken());
         Cookie refreshCookie = new Cookie("refreshToken", refreshTokenResponse.getRefreshToken());
 
+        accessCookie.setHttpOnly(true);
+        refreshCookie.setHttpOnly(true);
+
         response.addCookie(accessCookie);
         response.addCookie(refreshCookie);
 

--- a/src/main/java/com/nhnacademy/front/controller/LoginController.java
+++ b/src/main/java/com/nhnacademy/front/controller/LoginController.java
@@ -25,7 +25,7 @@ public class LoginController {
     }
 
     @PostMapping("/login")
-    public String login(LoginRequest loginRequest, Model model, HttpServletResponse response){
+    public String login(LoginRequest loginRequest, HttpServletResponse response){
         Map<String, Object> tokens = userAdaptor.doLogin(loginRequest);
 
         AccessTokenResponse accessTokenResponse = (AccessTokenResponse) tokens.get("accessToken");

--- a/src/main/java/com/nhnacademy/front/controller/LoginController.java
+++ b/src/main/java/com/nhnacademy/front/controller/LoginController.java
@@ -3,11 +3,16 @@ package com.nhnacademy.front.controller;
 import com.nhnacademy.front.adaptor.UserAdaptor;
 import com.nhnacademy.front.dto.AccessTokenResponse;
 import com.nhnacademy.front.dto.LoginRequest;
+import com.nhnacademy.front.dto.RefreshTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -20,9 +25,17 @@ public class LoginController {
     }
 
     @PostMapping("/login")
-    public String login(LoginRequest loginRequest, Model model){
-        AccessTokenResponse token = userAdaptor.doLogin(loginRequest);
-        model.addAttribute("token", token);
+    public String login(LoginRequest loginRequest, Model model, HttpServletResponse response){
+        Map<String, Object> tokens = userAdaptor.doLogin(loginRequest);
+
+        AccessTokenResponse accessTokenResponse = (AccessTokenResponse) tokens.get("accessToken");
+        RefreshTokenResponse refreshTokenResponse = (RefreshTokenResponse) tokens.get("refreshToken");
+
+        Cookie accessCookie = new Cookie("accessToken", accessTokenResponse.getAccessToken());
+        Cookie refreshCookie = new Cookie("refreshToken", refreshTokenResponse.getRefreshToken());
+
+        response.addCookie(accessCookie);
+        response.addCookie(refreshCookie);
 
         return "redirect:/";
     }

--- a/src/main/java/com/nhnacademy/front/dto/AccessTokenResponse.java
+++ b/src/main/java/com/nhnacademy/front/dto/AccessTokenResponse.java
@@ -1,12 +1,19 @@
 package com.nhnacademy.front.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccessTokenResponse {
+    @JsonProperty("access_token")
     private String accessToken;
+    @JsonProperty("token_type")
     private String tokenType;
-    private String expireIn;
+    @JsonProperty("expire_in")
+    private Integer expiresIn;
 }

--- a/src/main/java/com/nhnacademy/front/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/nhnacademy/front/dto/RefreshTokenResponse.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.front.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshTokenResponse {
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("expire_in")
+    private Integer expiresIn;
+}


### PR DESCRIPTION
### 작업 내용
- 인증서버에서 응답하는 형태로 UserAdaptor 리턴타입 변경
- refresh token을 사용하기 위해 dto 추가
- access token response 필드 이름 인증서버 응답 형태로 변경
- LoginController에서 access token cookie와 response token cookie 넣게 수정